### PR TITLE
Re-ordering document, Vendor intergration must happen *after* ethernet 1/2 assigned as 'default' virtual router

### DIFF
--- a/HowTos/UCC_Release_Notes.rst
+++ b/HowTos/UCC_Release_Notes.rst
@@ -3,6 +3,17 @@ Release Notes
 =======================================
 
 
+6.3.2548 (11/04/2021)
+=====================
+
+**Issues Corrected in Aviatrix Release 6.3**
+
+- **AVX-15897** - Fixed an issue for Gateway Replace/Create/ForceUpgrade operations if Splunk logging was enabled on it, which was seen on all releases after 10/13/2021 (when Splunk behavior changed).
+- **AVX-15985** - Fixed the issue where the Controller get_gateway_stats API was returning stats for deleted interfaces.
+- **AVX-16017** - Users were unable to create Microsoft Azure Resource Manager (ARM) China Gateway for the 6.3 version. This issue was fixed by updating an Azure China image link for 6.3.
+- This release includes a fix for the security vulnerability AVI-2021-0006 that would allow an unauthenticated attacker to execute arbitrary code on the Controller (this vulnerability was also fixed by our security patch released on 10/25/2021 as described here https://docs.aviatrix.com/HowTos/UCC_Release_Notes.html#security-patch-note-10-25-2021).
+
+
 Security Patch Note for Controllers (11/01/21)
 ===================================================================== 
 

--- a/HowTos/copilot_getting_started.rst
+++ b/HowTos/copilot_getting_started.rst
@@ -11,16 +11,16 @@ Aviatrix CoPilot Deployment Guide
 Launch CoPilot
 ==================
 
-CoPilot is available as an all-in-one virtual appliance that's hosted in users' own IaaS cloud environment. 
-It can be launched as an EC2 instance in AWS, virtual machine in Azure, or a VM instances in GCP and OCI. Please make sure default configurations for resources settings that are recommended by marketplaces are applied during launch.
-After successfully launching the instance, follow this steps to configure CoPilot instance parameters and launch. 
+Aviatrix CoPilot is available as an all-in-one virtual appliance that is hosted in a user's own IaaS cloud environment. 
+It can be launched as an EC2 instance in AWS, a virtual machine in Azure, or a VM instance in GCP and OCI. Please make sure default configurations for resources settings that are recommended by marketplaces are applied during launch.
+After successfully launching the instance, follow these steps to configure CoPilot instance parameters and launch. 
 Please note that you will need an Aviatrix Controller to use CoPilot. CoPilot is not a separate product.
 
 
 Instance Configuration Details
 ------------------------------
 
-- Configure your copilot security group as shown below to allow the following: 
+- Configure your CoPilot security group as shown below to allow the following: 
 
   - 443 from anywhere user access (User Interface)
 
@@ -29,46 +29,46 @@ Instance Configuration Details
   - UDP port 31283 from 0.0.0.0/0 or specific gateway IPs 
 
 .. tip::
-  If security requirement dictates that security groups not be open to 0.0.0.0/0, you can program the security group to open this UDP port to aviatrix gateway EIPs. You can leverage controllers security group management to copy the IP addresses of the gateways 
+  If a security requirement dictates that security groups not be open to 0.0.0.0/0, you can program the security group to open this UDP port to Aviatrix gateway EIPs. You can leverage Controller's security group management to copy the IP addresses of the gateways. 
 
  
 
-Configure controllers access for CoPilot
+Configure Controller's access for CoPilot
 =============================================
 
-- Assign a static public IP address to CoPilot. For example, in EC2 console, you go to Elastic IP section and assign an EIP to copilot instance 
+- Assign a static public IP address to CoPilot. For example, in EC2 console, you go to the Elastic IP section and assign an EIP to the CoPilot instance. 
 
-- On controller security groups, ensure 443 is open to public IP  of CoPilot instance
+- On Controller security groups, ensure 443 is open to the public IP of the CoPilot instance.
 
-- Configure a dedicate user account on aviatrix controller for copilot 
+- Configure a dedicate user account on Aviatrix Controller for CoPilot. 
 
-- You should now be able to login to CoPilot with the credentials we configured above
+- You should now be able to log in to CoPilot with the credentials we configured above.
 
 .. note::
-  If you are using RBAC, as of 1.1.5 Copilot requires read-only access + access to ping and traceroute functions for diagnostic capabilities
+  If you are using RBAC, as of 1.1.5 CoPilot requires read-only access + access to ping and traceroute functions for diagnostic capabilities.
 
 
 Enable Syslog for Performance Monitoring
 ==============================================
 
-- Login to Aviatrix controller 
+- Log in to Aviatrix Controller. 
 
-- Go to Settings -> Loggings -> Remote Syslog
+- Go to Settings -> Loggings -> Remote Syslog.
 
-- Enable the Service, choose a Profile Index (ie. 0), and use the EIP of copilot as the server and UDP port 5000 (default) 
+- Enable the Service, choose a Profile Index (ie. 0), and use the EIP of CoPilot as the server and UDP port 5000 (default). 
 
 
 Enable FlowIQ
 =================
 
-- Login to Aviatrix controller 
+- Log in to Aviatrix Controller. 
 
-- Go to Settings -> Loggings -> NetFlow Logging
+- Go to Settings -> Loggings -> NetFlow Logging.
 
-- Use the EIP of copilot as the server and UDP port 31283 (default) 
+- Use the EIP of CoPilot as the server and UDP port 31283 (default). 
 
  
-Deployment is complete. At this point your Copilot is setup and ready to use. You should start seeing NetFlow in less than 5 minutes. Note that when you launch CoPilot at first your version number will be based on the version in the image. Within an hour, Copilot version will be updated.
+Deployment is complete. At this point your CoPilot is set up and ready to use. You should start seeing NetFlow in less than 5 minutes. Note that when you launch CoPilot at first your version number will be based on the version in the image. Within an hour, the CoPilot version will be updated.
 
 System Design Considerations 
 ==================================
@@ -78,29 +78,29 @@ System Design Considerations
 Deploy Aviatrix CoPilot in GCP
 ==============================
 
-- Go to GCP marketplace
+- Go to GCP marketplace.
 
-- Find the product "Aviatrix CoPilot - BYOL"
+- Find the product "Aviatrix CoPilot - BYOL".
 
-- Click the button "LAUNCH"
+- Click the button "LAUNCH".
 
 |gcp_copilot_1|
 
-- Make sure the selected Machine type has at least 8 vCPUs with 32 GB memory
+- Make sure the selected Machine type has at least 8 vCPUs with 32 GB memory.
 
-- Boot Disk is SSD Persistnent Disk with 2000 GB
+- Boot Disk is SSD Persistent Disk with 2000 GB.
 
 |gcp_copilot_2|
 
-- 443 from anywhere user access (User Interface)
+- 443 from anywhere user access (User Interface).
 
-- UDP port 31283 from 0.0.0.0/0 or specific gateway IPs
+- UDP port 31283 from 0.0.0.0/0 or specific gateway IPs.
 
-- UDP port 5000 from 0.0.0.0/0 or specific gateway IPs
+- UDP port 5000 from 0.0.0.0/0 or specific gateway IPs.
 
 |gcp_copilot_3|
 
-- Click the button "Deploy"
+- Click the button "Deploy".
 
 .. |gcp_copilot_1| image:: copilot_getting_started_media/gcp_copilot_1.png
    :scale: 50%

--- a/HowTos/copilot_getting_started.rst
+++ b/HowTos/copilot_getting_started.rst
@@ -14,7 +14,7 @@ Launch CoPilot
 Aviatrix CoPilot is available as an all-in-one virtual appliance that is hosted in a user's own IaaS cloud environment. 
 It can be launched as an EC2 instance in AWS, a virtual machine in Azure, or a VM instance in GCP and OCI. Please make sure default configurations for resources settings that are recommended by marketplaces are applied during launch.
 After successfully launching the instance, follow these steps to configure CoPilot instance parameters and launch. 
-Please note that you will need an Aviatrix Controller to use CoPilot. CoPilot is not a separate product.
+Please note that you will need an Aviatrix Controller to use CoPilot. CoPilot is not a separate product. Aviatrix Controller and CoPilot are not required to be collocated. It is possible to run them in separate VPCs/VNETs or separate cloud providers (in multi-cloud environments).
 
 
 Instance Configuration Details

--- a/HowTos/copilot_overview.rst
+++ b/HowTos/copilot_overview.rst
@@ -30,7 +30,7 @@ Deployment Model
 
 CoPilot is deployed as an all-in-one virtual appliance and is available on AWS, Azure, GCP, and OCI MarketPlaces.
 CoPilot works in tandem with Aviatrix Controller; in order to use CoPilot, you must have an operational 
-Aviatrix Controller. 
+Aviatrix Controller. Aviatrix Controller and CoPilot are not required to be collocated. It is possible to run them in separate VPCs/VNETs or separate cloud providers (in multi-cloud environments).
 
 Licensing and Trials
 ---------------------

--- a/HowTos/copilot_release_notes.rst
+++ b/HowTos/copilot_release_notes.rst
@@ -7,6 +7,115 @@
 Aviatrix CoPilot Release Notes
 ============================================================
 
+Release 1.4.8
+-----------------
+- **New: ThreatGuard** You can now block and get alerted on the threats detected in your network. A dashboard to configure and view ThreatGuard in action.
+- **Enhancement** Improved alerts.
+- **Enhancement** More metrics. All of Performance V2 metrics are now supported for receiving alerts.
+- **Enhancement** Ability to pick and choose one/more/all hosts and one/more/all of interfaces to receive telemetry and node status alerts.
+- **Enhancement** Support for filtering domains and hosts in Network Segmentation graphs.
+- **Enhancement** Faster Cloud Routes pages and faster Notifications page.
+- **Enhancement** Performance improvements.
+- **Bug fix** Minor bug fixes.
+
+Release 1.4.7.4
+-----------------
+- **Bug fix** Fixes to latencies in Topology.
+
+Release 1.4.7.3
+-----------------
+- **Enhancement** Improvements to GW, Tunnel, S2C alerts.
+- **Enhancement** Performance improvements in backend tasks.
+- **Enhancement** Configurable settings for Network Segmentation charts.
+- **Bug fix** Fix in V2 Telemetry alerts.
+
+
+Release 1.4.7.2
+-----------------
+- **Bug fix** Fixes to Legend in Network Segmentation Page.
+- Revert ETL migration for Customers with older than 6.4 Controllers
+- **Bug fix** Minor improvements to Performance V2 Charts.
+
+
+Release 1.4.7.1
+-----------------
+- **Bug fix** Minor bug fixes in Performance Monitor V2.
+
+Release 1.4.7
+-----------------
+- **New: ThreatIQ** Real time identification of threats in ThreatIQ.
+- **Enhancement** Performance V2. Many more metrics to monitor performance of hosts, interfaces and tunnels. In the Performance Page, click on **Switch to V2**.
+- **Enhancement** Latencies for Site 2 Cloud links.
+- **Enhancement** You can now filter topology data by node type.
+- **Enhancement** Improved Cloud Routes Search and show only the routes with longest prefix.
+- **Enhancement** Upgraded AppIQ with V2 performance metrics.
+- **Enhancement** Performance improvements.
+- **Bug fix** Minor bug fixes.
+
+
+Release 1.4.6.4
+-----------------
+- **Bug fix** Fixes to SSO login.
+
+
+Release 1.4.6.3
+-----------------
+- **Enhancement** Improvements to individual alerts per host.
+- **Enhancement** In Dashboard, added a chart for instances per region.
+- **Bug fix** Fixes to topology replay.
+- **Bug fix** Fixes to topology saved layouts.
+
+
+Release 1.4.6.3
+-----------------
+- **Enhancement** Improvements to individual alerts per host.
+- **Enhancement** In Dashboard, added a chart for instances per region.
+- **Bug fix** Fixes to topology replay.
+- **Bug fix** Fixes to topology saved layouts.
+
+
+Release 1.4.6.2
+-----------------
+- **Bug fix** Fix to the offline upgrade process.
+
+
+Release 1.4.1
+-----------------
+- **Bug fix** Fix in Webhooks test button.
+
+Release 1.4.6
+-----------------
+- **Enhancement** You can now receive individual alert notifications for each host.
+- **Enhancement** AppIQ now works across all clouds.
+- **Enhancement** In Topology, you can show and hide latencies.
+- **Bug fix** Fixes for Dashboard Charts.
+- **Bug fix** Fixes for Security Charts.
+
+Release 1.4.5.3
+-----------------
+- **Enhancement** In Dashboard, new chart for Instances Per Cloud.
+- **Bug fix** Fixes for Gateways Active Sessions and Interfaces.
+- **Bug fix** Fixes for Security Charts.
+
+Release 1.4.5.2
+-----------------
+- **Enhancement** Security updates.
+- **Bug fix** Webhook templates bug fix.
+
+
+Release 1.4.5.1
+-----------------
+- **Bug fixes** Minor bug fixes in Dashboard pie charts and VPC Routes.
+
+Release 1.4.5
+-----------------
+- **Enhancement** Support for offline upgrade and offline installation of CoPilot.
+- **Enhancement** Support for templates in Webhooks.
+- **Enhancement** Support for Alibaba Cloud.
+- **Settings -> Index Management** Support for searching and filtering indices.
+- **Bug fixes** Minor bug fixes.
+
+
 Release 1.4.4
 -----------------
 - **Bug fix** Performance Fixes for Dashboard - Overview and Traffic Pages load faster.
@@ -24,7 +133,7 @@ Release 1.4.3
 - **Dashboard -> Traffic page** Detailed metrics on data sent and received in the last hour and day for instances, regions, GWs and VPCs/VNETs/VCNs. Also shows the trend and detailed traffic chart for each cloud construct. Ties into FlowIQ for deeper visibility.
 - **Security -> Audit** End to end audit on every API call (with response status, user who made the call, arguments for the call), aggregated hourly, daily, monthly and fully searchable, filterable and sortable.
 - **Search for titles/notes in the topology replay timeline across timestamps** Replay now ties into Audit so that you know who made the infrastructure change(s) and when it was (they were) made.
-- **SSO** Configure Copilot in the controller UI and login into copilot from the Controller directly without having to enter the credentials. 
+- **SSO** Configure CoPilot in the Controller UI and login into CoPilot from the Controller directly without having to enter the credentials. 
 - **Cloud Routes and BGP** section now scale to work with Controller 6.4 API changes, backward compatible with pre-6.4 APIs.
 - **Cloud Routes Search** Search, filter and highlight across routes/GWs for anything you see on the page (name, routes, cloud provider, status, tunnels). Search for IP in Subnet also highlights which CIDR the IP is part of.
 - Look and feel improvements for Settings Pages and Notifications page.
@@ -34,7 +143,7 @@ Release 1.4.3
 Release 1.4.2.1
 -----------------
 - A patch update to the release 1.4.2 
-- **Improvement** in scalability and security. Support 100k+ changes in topology diff and more than 250k tunnels in the cloud routes section (which is about 40MB of tunnels data rendered in less than 5 secs). We also made improvements to our middleware to secure Copilot. We now logout the user immediately from accessing copilot data, if the user gets deleted from the controller.
+- **Improvement** in scalability and security. Support 100k+ changes in topology diff and more than 250k tunnels in the cloud routes section (which is about 40MB of tunnels data rendered in less than 5 secs). We also made improvements to our middleware to secure CoPilot. We now logout the user immediately from accessing copilot data, if the user gets deleted from the Controller.
 
 
 Release 1.4.2
@@ -56,7 +165,7 @@ Releases 1.4.0.1, 1.4.0.2
 ----------------------------
 
 - **Enhancement** Enhanced Topology Replay to add zoom and move to preview timeline
-- **Enhancement** Throttle Latency Calls to reduce controller cpu usage (for large scale env), removed duplicate latency calls for edges
+- **Enhancement** Throttle Latency Calls to reduce Controller cpu usage (for large scale env), removed duplicate latency calls for edges
 - **Bug fix** Topology Transit View - Single node clusters for VPC, Fix for Spokes with Peering Connections, Connect S2C to regions
 - **Bug fix** Dashboard not showing OCI in Geo Map
 - **Bug fix** Segments not showing up randomly on Domain Segmentation. Truncate long labels and add tooltip
@@ -65,7 +174,7 @@ Releases 1.4.0.1, 1.4.0.2
 Release 1.4.0
 -------------------
 
-- **Copilot Theme** New Dark Mode The moon icon in the Copilot header can be toggled to switch between light mode and dark mode.
+- **CoPilot Theme** New Dark Mode The moon icon in the CoPilot header can be toggled to switch between light mode and dark mode.
 - **Topology Replay** Full view of what’s changed in your infrastructure. Instantly see any change (for ex: GWs go up/down, tunnels flap, peerings added) to your topology at any timestamp and manage your changesets.
 - **Multi Cloud Network Segmentation** Now in Security tab, Logical view -> you can visualize which spoke (or Site2Cloud instance) can reach which other spokes based on the security domains they are part of. In the physical view -> you can visualize the spokes (or S2C instances) grouped by the transit gateways and their reachability based on the security domains they are attached to.
 - **Transit View for Topology** Topology Revamped. Clear the clutter and visualize multi-cloud topology with just the Aviatrix transits connected to regions. Double click to open/close VPC/VNET clusters.
@@ -157,8 +266,8 @@ Release 1.2.0.5
 
 Release 1.2.0.3
 -------------------
-Version 1.2.0.3 requires users to enter valid credentials for the controller that Copilot will store as a **Service Account**. This Service Account is needed
-so Copilot can process and send alerts based on configured thresholds. This Service Account can be a read-only account the user created on
+Version 1.2.0.3 requires users to enter valid credentials for the Controller that CoPilot will store as a **Service Account**. This Service Account is needed
+so CoPilot can process and send alerts based on configured thresholds. This Service Account can be a read-only account the user created on
 the controller. This dialog will only show one time when no service account has been configured.
 The Service Account can be changed in **Settings** .
 

--- a/HowTos/firewall_network_faq.rst
+++ b/HowTos/firewall_network_faq.rst
@@ -41,7 +41,7 @@ On-prem to VPC traffic inspection               Yes                             
 VPC to VPC traffic inspection                   Yes (requires SNAT)                     Yes                               Yes
 Egress traffic inspection                       Yes                                     Yes                               Yes
 Per firewall performance                        500Mbps                                 Up to 6Gbps                       Up to 6Gbps
-Total FireNet performance                       > 500Mbps                               Up to 6Gbps                       40Gbps
+Total FireNet performance                       > 500Mbps                               Up to 6Gbps                       up to 75Gbps
 Multiple firewalls (scale out)                  Yes                                     No (Active/Standby)               Yes
 Integrated solution                             Yes                                     No (requires external script)     Yes        
 Solution complexity                             High                                    Medium                            Low


### PR DESCRIPTION
Before ethernet 1/2 assigned as 'default' virtual router, run Vendor integration will get you this screen:

![image](https://user-images.githubusercontent.com/93721751/140806994-d59457fc-ea86-45e8-aa83-f169ecc98723.png)

Hence must change the deployment order.
